### PR TITLE
migration to sdk 2.0, asynchronous rewrite using rxjava primitives

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,9 +96,9 @@
       <version>14.0-rc2</version>
     </dependency>
     <dependency>
-      <groupId>couchbase</groupId>
+      <groupId>com.couchbase.client</groupId>
       <artifactId>couchbase-client</artifactId>
-      <version>1.1.6</version>
+      <version>2.0.0-beta</version>
     </dependency>
     <!-- UNIT TESTING -->
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -86,9 +86,9 @@
       <version>1.0.9</version>
     </dependency>
     <dependency>
-      <groupId>com.flaptor</groupId>
-      <artifactId>hist4j</artifactId>
-      <version>1.0</version>
+      <groupId>org.hdrhistogram</groupId>
+      <artifactId>HdrHistogram</artifactId>
+      <version>1.2.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.guava</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -16,8 +16,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>2.3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
             <plugin>

--- a/src/main/java/com/couchbase/roadrunner/GlobalConfig.java
+++ b/src/main/java/com/couchbase/roadrunner/GlobalConfig.java
@@ -22,11 +22,10 @@
 
 package com.couchbase.roadrunner;
 
-import java.net.URI;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+
 import org.apache.commons.cli.CommandLine;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,7 +54,7 @@ final  class GlobalConfig {
   public static final String DEFAULT_RAMP = "0";
   public static final String DEFAULT_SIZE = "1000";
 
-  private final List<URI> nodes;
+  private final List<String> nodes;
   private final String bucket;
   private final String password;
   private final int numThreads;
@@ -71,13 +70,13 @@ final  class GlobalConfig {
   /**
    * Create the GlobalConfig.
    *
-   * @param nodes The list of nodes, separated by ",".
+   * @param nodes The list of nodes, as String urls.
    * @param bucket The name of the bucket.
    * @param password The password of the bucket.
    * @param numThreads The number of threads.
    * @param numClients The number of CouchbaseClients.
    */
-  private GlobalConfig(List<URI> nodes, String bucket, String password,
+  private GlobalConfig(List<String> nodes, String bucket, String password,
     int numThreads, int numClients, long numDocs, int ratio, int sampling,
     String workload, int ramp, int size, String filename) {
     this.nodes = Collections.unmodifiableList(nodes);
@@ -135,27 +134,17 @@ final  class GlobalConfig {
   /**
    * Converts the node string into a list of URIs.
    *
-   * @param nodes The node list as a string.
-   * @return The converted list of URIs.
+   * @param nodes The node list as a single string.
+   * @return The nodes converted to a list of Strings (one for each node).
    */
-  private static List<URI> prepareNodeList(final String nodes) {
-    List<String> splitNodes = Arrays.asList(nodes.split(","));
-    List<URI> converted = new ArrayList<URI>();
-    try {
-      for (String node : splitNodes) {
-        converted.add(new URI("http://" + node + ":8091/pools"));
-      }
-    } catch (Exception ex) {
-      LOGGER.error("Could not parse node list: " + ex);
-      System.exit(-1);
-    }
-    return converted;
+  private static List<String> prepareNodeList(final String nodes) {
+    return Arrays.asList(nodes.split(","));
   }
 
   /**
    * @return the nodes
    */
-  public List<URI> getNodes() {
+  public List<String> getNodes() {
     return nodes;
   }
 

--- a/src/main/java/com/couchbase/roadrunner/RoadRunner.java
+++ b/src/main/java/com/couchbase/roadrunner/RoadRunner.java
@@ -131,12 +131,12 @@ public final class RoadRunner {
     long totalOps = dispatcher.getTotalOps();
     long measuredOps = dispatcher.getMeasuredOps();
 
-    LOGGER.info("Operations: measured " + measuredOps + "ops out of total "
+    LOGGER.info("Operations: measured " + measuredOps + " ops out of total "
       + totalOps + "ops.");
 
     Map<String, List<Stopwatch>> measures = dispatcher.getMeasures();
     for (Map.Entry<String, List<Stopwatch>> entry : measures.entrySet()) {
-      Histogram h = new Histogram(60*60*1000, 5);
+      Histogram h = new Histogram(10*60*1000*1000, 5);
       for (Stopwatch watch : entry.getValue()) {
         h.recordValue(watch.elapsed(TimeUnit.MICROSECONDS));
       }

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
@@ -65,8 +65,7 @@ public class GetSetWorkload extends Workload {
         if(++samplingCount == sampling) {
           //launch a measured "set" operation followed by ratio "get" operations, also measured
           setWorkloadWithMeasurement(key)
-              .repeat(ratio)
-              .flatMap(docInDb -> getWorkloadWithMeasurement(key))
+              .flatMap(docInDb -> getWorkloadWithMeasurement(key).repeat(ratio))
               .doOnError(ex -> getLogger().info("Problem while measured set/get key" + ex.getMessage()))
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {
@@ -78,8 +77,7 @@ public class GetSetWorkload extends Workload {
         } else {
           //launch a simple "set" operation, followed by ratio "get" operations
           setWorkload(key)
-              .repeat(ratio)
-              .flatMap(docInDb -> getWorkload(key))
+              .flatMap(docInDb -> getWorkload(key).repeat(ratio))
               .doOnError(ex -> getLogger().info("Problem while set/get key" + ex.getMessage()))
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
@@ -71,7 +71,8 @@ public class GetSetWorkload extends Workload {
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {
                 if (last) latch.countDown();
-              });
+              })
+              .subscribe();
 
           samplingCount = 0;
         } else {
@@ -83,7 +84,8 @@ public class GetSetWorkload extends Workload {
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {
                 if (last) latch.countDown();
-              });
+              })
+          .subscribe();
         }
     }
 
@@ -97,13 +99,13 @@ public class GetSetWorkload extends Workload {
   }
 
   private Observable<LegacyDocument> setWorkloadWithMeasurement(String key) {
-    Stopwatch watch = new Stopwatch().start();
-    Observable<LegacyDocument> result = setWorkload(key);
-    result.doOnTerminate(() -> {
-      watch.stop();
-      addMeasure("set", watch);
+    return Observable.defer(() -> {
+      Stopwatch watch = new Stopwatch().start();
+      return  setWorkload(key).doOnTerminate(() -> {
+        watch.stop();
+        addMeasure("set", watch);
+      });
     });
-    return result;
   }
 
   private Observable<LegacyDocument> setWorkload(String key)  {
@@ -117,13 +119,14 @@ public class GetSetWorkload extends Workload {
   }
 
   private Observable<LegacyDocument> getWorkloadWithMeasurement(String key) {
-    Stopwatch watch = new Stopwatch().start();
-    Observable<LegacyDocument> result = getWorkload(key);
-    result.doOnTerminate(() -> {
-      watch.stop();
-      addMeasure("get", watch);
+    return Observable.defer(() -> {
+      Stopwatch watch = new Stopwatch().start();
+      return getWorkload(key)
+            .doOnTerminate(() -> {
+              watch.stop();
+              addMeasure("get", watch);
+            });
     });
-    return result;
   }
 
   private Observable<LegacyDocument> getWorkload(String key) {

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
@@ -66,7 +66,7 @@ public class GetSetWorkload extends Workload {
           //launch a measured "set" operation followed by ratio "get" operations, also measured
           setWorkloadWithMeasurement(key)
               .flatMap(docInDb -> getWorkloadWithMeasurement(key).repeat(ratio))
-              .doOnError(ex -> getLogger().info("Problem while measured set/get key" + ex.getMessage()))
+              .doOnError(ex -> getLogger().info("Problem while measured set/get key" + ex))
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {
                 if (last) latch.countDown();
@@ -78,7 +78,7 @@ public class GetSetWorkload extends Workload {
           //launch a simple "set" operation, followed by ratio "get" operations
           setWorkload(key)
               .flatMap(docInDb -> getWorkload(key).repeat(ratio))
-              .doOnError(ex -> getLogger().info("Problem while set/get key" + ex.getMessage()))
+              .doOnError(ex -> getLogger().info("Problem while set/get key" + ex))
               //schedule the ending of the timer at the last iteration
               .finallyDo(() -> {
                 if (last) latch.countDown();

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetSetWorkload.java
@@ -101,7 +101,7 @@ public class GetSetWorkload extends Workload {
   private Observable<LegacyDocument> setWorkloadWithMeasurement(String key) {
     return Observable.defer(() -> {
       Stopwatch watch = new Stopwatch().start();
-      return  setWorkload(key).doOnTerminate(() -> {
+      return  setWorkload(key).finallyDo(() -> {
         watch.stop();
         addMeasure("set", watch);
       });
@@ -113,7 +113,7 @@ public class GetSetWorkload extends Workload {
     Observable<LegacyDocument> result = Observable.defer(() ->
         getBucket()
             .insert(value)
-            .doOnEach(doc -> incrTotalOps())
+            .doOnNext(doc -> incrTotalOps())
     );
     return result;
   }
@@ -122,7 +122,7 @@ public class GetSetWorkload extends Workload {
     return Observable.defer(() -> {
       Stopwatch watch = new Stopwatch().start();
       return getWorkload(key)
-            .doOnTerminate(() -> {
+            .finallyDo(() -> {
               watch.stop();
               addMeasure("get", watch);
             });
@@ -133,7 +133,7 @@ public class GetSetWorkload extends Workload {
     return Observable.defer(() ->
             getBucket()
                 .get(key, LegacyDocument.class)
-                .doOnEach(doc -> incrTotalOps())
+                .doOnNext(doc -> incrTotalOps())
     );
   }
 

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
@@ -111,7 +111,7 @@ public class GetsCasWorkload extends Workload {
     return Observable.defer(() ->
             getBucket()
                 .upsert(doc)
-                .doOnEach(item -> incrTotalOps())
+                .doOnNext(item -> incrTotalOps())
     );
   }
 
@@ -119,7 +119,7 @@ public class GetsCasWorkload extends Workload {
     return Observable.defer(() -> {
       Stopwatch watch = new Stopwatch().start();
       return getsWorkload(key)
-          .doOnTerminate(() -> {
+          .finallyDo(() -> {
             watch.stop();
             addMeasure("gets", watch);
           });
@@ -130,7 +130,7 @@ public class GetsCasWorkload extends Workload {
     return Observable.defer(() -> {
       Stopwatch watch = new Stopwatch().start();
       return casWorkload(key, cas, doc)
-          .doOnTerminate(() -> {
+          .finallyDo(() -> {
             watch.stop();
             addMeasure("cas", watch);
           });
@@ -142,7 +142,7 @@ public class GetsCasWorkload extends Workload {
       getBucket()
         .get(key, LegacyDocument.class)
         .map(doc -> doc.cas())
-        .doOnEach(item -> incrTotalOps())
+        .doOnNext(item -> incrTotalOps())
     );
   }
 
@@ -151,7 +151,7 @@ public class GetsCasWorkload extends Workload {
     return Observable.defer(() ->
       getBucket()
         .replace(doc)
-        .doOnEach(item -> incrTotalOps())
+        .doOnNext(item -> incrTotalOps())
         .doOnError(ex -> getLogger().info("Could not store with cas for key: " + key))
         .onErrorReturn(ex -> doc)
     );

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
@@ -27,6 +27,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.couchbase.client.java.Bucket;
 import com.couchbase.client.java.document.LegacyDocument;
+import com.couchbase.client.java.error.CASMismatchException;
 import com.google.common.base.Stopwatch;
 
 import rx.Observable;
@@ -152,7 +153,12 @@ public class GetsCasWorkload extends Workload {
       getBucket()
         .replace(doc)
         .doOnNext(item -> incrTotalOps())
-        .doOnError(ex -> getLogger().info("Could not store with cas for key: " + key))
+          .doOnError(ex -> {
+            if (ex instanceof CASMismatchException)
+              getLogger().info("Could not store with cas for key: " + key);
+            else
+              getLogger().info("Unexpected error while storing cas for key " + key + " : " + ex);
+          })
         .onErrorReturn(ex -> doc)
     );
   }

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
@@ -71,8 +71,7 @@ public class GetsCasWorkload extends Workload {
 
       if(++samplingCount == sampling) {
         addWorkload(key, getDocument())
-            .repeat(ratio)
-            .flatMap(d -> getsWorkloadWithMeasurement(key))
+            .flatMap(d -> getsWorkloadWithMeasurement(key).repeat(ratio))
             .flatMap(cas -> casWorkloadWithMeasurement(key, cas, getDocument()))
             .doOnError(ex -> getLogger().info("Problem while measured gets/cas key: " + ex.getMessage()))
             .finallyDo(() -> { if (last) latch.countDown(); })
@@ -80,8 +79,7 @@ public class GetsCasWorkload extends Workload {
         samplingCount = 0;
       } else {
         addWorkload(key, getDocument())
-            .repeat(ratio)
-            .flatMap(d -> getsWorkload(key))
+            .flatMap(d -> getsWorkload(key).repeat(ratio))
             .flatMap(cas -> casWorkload(key, cas, getDocument()))
             .doOnError(ex -> getLogger().info("Problem while gets/cas key: " + ex.getMessage()))
             .finallyDo(() -> { if (last) latch.countDown(); })

--- a/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/GetsCasWorkload.java
@@ -73,7 +73,7 @@ public class GetsCasWorkload extends Workload {
         addWorkload(key, getDocument())
             .flatMap(d -> getsWorkloadWithMeasurement(key).repeat(ratio))
             .flatMap(cas -> casWorkloadWithMeasurement(key, cas, getDocument()))
-            .doOnError(ex -> getLogger().info("Problem while measured gets/cas key: " + ex.getMessage()))
+            .doOnError(ex -> getLogger().info("Problem while measured gets/cas key: " + ex))
             .finallyDo(() -> { if (last) latch.countDown(); })
         .subscribe();
         samplingCount = 0;
@@ -81,7 +81,7 @@ public class GetsCasWorkload extends Workload {
         addWorkload(key, getDocument())
             .flatMap(d -> getsWorkload(key).repeat(ratio))
             .flatMap(cas -> casWorkload(key, cas, getDocument()))
-            .doOnError(ex -> getLogger().info("Problem while gets/cas key: " + ex.getMessage()))
+            .doOnError(ex -> getLogger().info("Problem while gets/cas key: " + ex))
             .finallyDo(() -> { if (last) latch.countDown(); })
         .subscribe();
       }

--- a/src/main/java/com/couchbase/roadrunner/workloads/Workload.java
+++ b/src/main/java/com/couchbase/roadrunner/workloads/Workload.java
@@ -36,7 +36,7 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.couchbase.client.CouchbaseClient;
+import com.couchbase.client.java.Bucket;
 import com.google.common.base.Charsets;
 import com.google.common.base.Stopwatch;
 import com.google.common.io.Files;
@@ -47,8 +47,8 @@ public abstract class Workload implements Runnable {
   private final Logger logger =
     LoggerFactory.getLogger(Workload.class.getName());
 
-  /** Reference to the CouchbaseClient */
-  private final CouchbaseClient client;
+  /** Reference to the Couchbase Bucket */
+  private final Bucket bucket;
 
   /** Name of the Workload */
   private final String workloadName;
@@ -70,9 +70,9 @@ public abstract class Workload implements Runnable {
 
   private final DocumentFactory documentFactory;
 
-  public Workload(final CouchbaseClient client, final String name,
+  public Workload(final Bucket bucket, final String name,
     final int ramp, final DocumentFactory documentFactory) {
-    this.client = client;
+    this.bucket = bucket;
     this.workloadName = name;
     this.measures = new HashMap<String, List<Stopwatch>>();
     this.measuredOps = 0;
@@ -135,10 +135,10 @@ public abstract class Workload implements Runnable {
   }
 
   /**
-   * @return the client
+   * @return the bucket
    */
-  public CouchbaseClient getClient() {
-    return client;
+  protected Bucket getBucket() {
+    return bucket;
   }
 
   /**

--- a/src/test/java/com/couchbase/roadrunner/GlobalConfigTest.java
+++ b/src/test/java/com/couchbase/roadrunner/GlobalConfigTest.java
@@ -28,7 +28,7 @@ public class GlobalConfigTest
     private static final String SIZE = "" + DOC_SIZE;
     private static final String FILENAME = "./file.json";
 
-    private static final String NODE_POOLS = "http://" + NODE + ":8091/pools";
+    private static final String NODE_POOLS = NODE;
 
     @Test
     public void testShortOptions() throws ParseException


### PR DESCRIPTION
This pull request is building upon my previous one (migrating to sdk 2.0 in blocking mode) and rewrites Workloads to extensively use RxJava primitives and Observables internally in order to be more asynchronous.
There still room for improvement (eg. waiting for all operations to stop in a workload is a bit sloppy as it relies on waiting for the last iteration...)